### PR TITLE
Improved rowReducer function to work with multiline output responses.

### DIFF
--- a/lib/rawToObject.js
+++ b/lib/rawToObject.js
@@ -72,7 +72,13 @@ function rowReducer(resultObj, row){
     let pair = row.split(ROW_SPLITTER);
 
     if(pair.length > 1){
-        resultObj[pair[0].trim()] = pair.slice(1).join(ROW_SPLITTER).trim();
+        const key = pair[0].trim();
+        const value = pair.slice(1).join(ROW_SPLITTER).trim();
+        if(key === 'Output' && typeof resultObj[key] === 'string' && resultObj[key] !== ''){
+            resultObj[key] += CRLF + value;
+        }else{
+            resultObj[key] = value;
+        }
     }
     return resultObj;
 }

--- a/test/utilsTest.js
+++ b/test/utilsTest.js
@@ -128,6 +128,26 @@ describe('Event utils test', () => {
             });
         });
 
+        it('with a multiline output response', () => {
+            let commandStr = [
+                    'Response: Success',
+                    'Message: Command output follows',
+                    'Output:   Version:                     16.1.1',
+                    'Output:   Build Options:               BUILD_NATIVE, OPTIONAL_API',
+                    'Output:   Maximum calls:               Not set'
+                ].join(CRLF) + CRLF.repeat(2);
+
+            assert.deepEqual(eventUtil.toObject(commandStr), {
+                Response: 'Success',
+                Message: 'Command output follows',
+                Output: [
+                    'Version:                     16.1.1',
+                    'Build Options:               BUILD_NATIVE, OPTIONAL_API',
+                    'Maximum calls:               Not set'
+                ].join(CRLF)
+            });
+        });
+
         it('without event\'s raw string', () => {
             assert.deepEqual(eventUtil.toObject(), {});
         });


### PR DESCRIPTION
Related with Issue #1.

We had the same difficulty processing responses with multiple line outputs.

Improved the function 'rowReducer' in order to return all the output lines as a single string (concatenated with "\r\n").

Used an adapted version of the test created by @minoruta.